### PR TITLE
fix: fix modifiers

### DIFF
--- a/modifier.go
+++ b/modifier.go
@@ -11,6 +11,7 @@ const modifierSequence = "\033[%dm"
 const (
 	Reset Modifier = iota
 	Bold
+	Faint
 	Italic
 	Underline
 )


### PR DESCRIPTION
Modifiers values were offset, as the `Faint` modifier was not set.